### PR TITLE
adds a fallback for the feed finder when a url is created

### DIFF
--- a/internal/discuss/hackernews.go
+++ b/internal/discuss/hackernews.go
@@ -25,13 +25,14 @@ func NewHackerNewsFetcher() *HackerNewsFetcher {
 func (f *HackerNewsFetcher) Name() string { return "hackernews" }
 
 func (f *HackerNewsFetcher) Fetch(ctx context.Context, rawURL string) ([]Discussion, error) {
-	params := url.Values{}
-	params.Set("tags", "story")
-	params.Set("query", rawURL)
-	params.Set("restrictSearchableAttributes", "url")
-	apiURL := "https://hn.algolia.com/api/v1/search?" + params.Encode()
+	u, _ := url.Parse("https://hn.algolia.com/api/v1/search")
+	q := u.Query()
+	q.Set("tags", "story")
+	q.Set("query", rawURL)
+	q.Set("restrictSearchableAttributes", "url")
+	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +69,14 @@ func (f *HackerNewsFetcher) Fetch(ctx context.Context, rawURL string) ([]Discuss
 		if strings.TrimRight(h.URL, "/") != target {
 			continue
 		}
+		itemURL, _ := url.Parse("https://news.ycombinator.com/item")
+		iq := itemURL.Query()
+		iq.Set("id", h.ObjectID)
+		itemURL.RawQuery = iq.Encode()
+
 		discussions = append(discussions, Discussion{
 			Title:         h.Title,
-			DiscussionURL: "https://news.ycombinator.com/item?id=" + h.ObjectID,
+			DiscussionURL: itemURL.String(),
 			Score:         h.Points,
 			CommentCount:  h.NumComments,
 		})

--- a/internal/discuss/lobsters.go
+++ b/internal/discuss/lobsters.go
@@ -42,9 +42,14 @@ func (f *LobstersFetcher) Fetch(ctx context.Context, rawURL string) ([]Discussio
 		return nil, ctx.Err()
 	}
 
-	feedURL := "https://lobste.rs/search.rss?order=relevance&what=stories&q=" + url.QueryEscape(rawURL)
+	u, _ := url.Parse("https://lobste.rs/search.rss")
+	q := u.Query()
+	q.Set("order", "relevance")
+	q.Set("what", "stories")
+	q.Set("q", rawURL)
+	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/discuss/reddit.go
+++ b/internal/discuss/reddit.go
@@ -82,8 +82,12 @@ func (f *RedditFetcher) Fetch(ctx context.Context, rawURL string) ([]Discussion,
 		return nil, fmt.Errorf("reddit auth: %w", err)
 	}
 
-	apiURL := "https://oauth.reddit.com/api/info?url=" + url.QueryEscape(rawURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	u, _ := url.Parse("https://oauth.reddit.com/api/info")
+	q := u.Query()
+	q.Set("url", rawURL)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +137,7 @@ func (f *RedditFetcher) Fetch(ctx context.Context, rawURL string) ([]Discussion,
 		}
 		discussions = append(discussions, Discussion{
 			Title:         d.Title,
-			DiscussionURL: "https://www.reddit.com" + d.Permalink,
+			DiscussionURL: (&url.URL{Scheme: "https", Host: "www.reddit.com"}).JoinPath(d.Permalink).String(),
 			Score:         d.Score,
 			CommentCount:  d.NumComments,
 		})

--- a/internal/server/userhandler/handler.go
+++ b/internal/server/userhandler/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/a-h/templ"
@@ -184,7 +185,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 	if r.TLS == nil {
 		scheme = "http"
 	}
-	baseURL := scheme + "://" + r.Host
+	baseURL := (&url.URL{Scheme: scheme, Host: r.Host}).String()
 
 	h.render(w, r, ui.Base("settings", h.navUser(r), userpages.UserDetailPage(user, keys, baseURL, "")))
 }

--- a/internal/server/userhandler/import.go
+++ b/internal/server/userhandler/import.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path/filepath"
 
 	"go.e64ec.com/booksmk/internal/auth"
@@ -46,7 +47,7 @@ func (h *Handler) handleImport(w http.ResponseWriter, r *http.Request) {
 		if r.TLS == nil {
 			scheme = "http"
 		}
-		baseURL := scheme + "://" + r.Host
+		baseURL := (&url.URL{Scheme: scheme, Host: r.Host}).String()
 
 		h.render(w, r, ui.Base("settings", h.navUser(r), userpages.UserDetailPage(user, keys, baseURL, importErrMsg)))
 	}

--- a/internal/ui/feeds/pages.templ
+++ b/internal/ui/feeds/pages.templ
@@ -2,6 +2,7 @@ package feeds
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -45,10 +46,10 @@ templ TimelinePage(feeds []store.Feed, groups []store.TimelineGroup, page int, h
 		}
 		<div class="pagination">
 			if page > 1 {
-				<a href={ templ.SafeURL(fmt.Sprintf("/feed?page=%d", page-1)) } class="btn btn-sm">← newer</a>
+				<a href={ templ.SafeURL(paginationURL("/feed", page-1)) } class="btn btn-sm">← newer</a>
 			}
 			if hasMore {
-				<a href={ templ.SafeURL(fmt.Sprintf("/feed?page=%d", page+1)) } class="btn btn-sm">older →</a>
+				<a href={ templ.SafeURL(paginationURL("/feed", page+1)) } class="btn btn-sm">older →</a>
 			}
 		</div>
 		if feedGroupingEnabled {
@@ -335,4 +336,15 @@ func since(t time.Time) string {
 	default:
 		return fmt.Sprintf("%dd", int(d.Hours()/24))
 	}
+}
+
+func paginationURL(basePath string, page int) string {
+	u, err := url.Parse(basePath)
+	if err != nil {
+		return basePath
+	}
+	q := u.Query()
+	q.Set("page", strconv.Itoa(page))
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/internal/ui/urls/pages.templ
+++ b/internal/ui/urls/pages.templ
@@ -3,6 +3,7 @@ package urls
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.e64ec.com/booksmk/internal/store"
@@ -328,7 +329,9 @@ func youtubeEmbedURL(rawURL string) string {
 	if videoID == "" {
 		return ""
 	}
-	return "https://www.youtube.com/embed/" + videoID
+	embedURL, _ := url.Parse("https://www.youtube.com/embed")
+	embedURL = embedURL.JoinPath(videoID)
+	return embedURL.String()
 }
 
 func hostname(rawURL string) string {
@@ -342,17 +345,21 @@ func hostname(rawURL string) string {
 templ pagination(basePath string, page int, hasMore bool) {
 	<div class="pagination">
 		if page > 1 {
-			<a href={ templ.SafeURL(fmt.Sprintf("%s%spage=%d", basePath, paramJoin(basePath), page-1)) } class="btn btn-sm">← newer</a>
+			<a href={ templ.SafeURL(paginationURL(basePath, page-1)) } class="btn btn-sm">← newer</a>
 		}
 		if hasMore {
-			<a href={ templ.SafeURL(fmt.Sprintf("%s%spage=%d", basePath, paramJoin(basePath), page+1)) } class="btn btn-sm">older →</a>
+			<a href={ templ.SafeURL(paginationURL(basePath, page+1)) } class="btn btn-sm">older →</a>
 		}
 	</div>
 }
 
-func paramJoin(path string) string {
-	if strings.Contains(path, "?") {
-		return "&"
+func paginationURL(basePath string, page int) string {
+	u, err := url.Parse(basePath)
+	if err != nil {
+		return basePath
 	}
-	return "?"
+	q := u.Query()
+	q.Set("page", strconv.Itoa(page))
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/internal/ui/urls/pages.templ
+++ b/internal/ui/urls/pages.templ
@@ -137,11 +137,11 @@ templ DetailPage(u store.URL, discussions []store.Discussion, subscribedFeed *st
 			</form>
 			if u.FeedURL != "" {
 				if subscribedFeed != nil {
-					<a href={ templ.SafeURL("/feed/" + subscribedFeed.ID.String()) } class="btn btn-sm">view feed ↗</a>
+					<a href={ templ.SafeURL("/feed/" + subscribedFeed.ID.String()) } class="btn btn-sm" style="margin-left:auto">view feed ↗</a>
 				} else {
 					<form method="POST" action="/feed" style="margin:0">
 						<input type="hidden" name="feed_url" value={ u.FeedURL }/>
-						<button type="submit" class="btn btn-sm btn-primary">subscribe to feed</button>
+						<button type="submit" class="btn btn-sm btn-primary" style="margin-left:auto">subscribe to feed</button>
 					</form>
 				}
 			}

--- a/internal/ui/urls/pages_templ.go
+++ b/internal/ui/urls/pages_templ.go
@@ -613,7 +613,7 @@ func DetailPage(u store.URL, discussions []store.Discussion, subscribedFeed *sto
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" class=\"btn btn-sm\">view feed ↗</a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" class=\"btn btn-sm\" style=\"margin-left:auto\">view feed ↗</a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -631,7 +631,7 @@ func DetailPage(u store.URL, discussions []store.Discussion, subscribedFeed *sto
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\"> <button type=\"submit\" class=\"btn btn-sm btn-primary\">subscribe to feed</button></form>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\"> <button type=\"submit\" class=\"btn btn-sm btn-primary\" style=\"margin-left:auto\">subscribe to feed</button></form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/internal/urlfetch/urlfetch.go
+++ b/internal/urlfetch/urlfetch.go
@@ -97,7 +97,9 @@ func findFeedAtBase(rawURL string) string {
 		return ""
 	}
 
-	baseURL := u.Scheme + "://" + u.Host + "/"
+	base := &url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/"}
+	baseURL := base.String()
+
 	body, _ := fetchPageHTML(baseURL)
 	if body == "" {
 		return ""
@@ -125,8 +127,13 @@ func youtubeOEmbedTitle(rawURL string) string {
 		return ""
 	}
 
-	oembedURL := "https://www.youtube.com/oembed?format=json&url=" + url.QueryEscape(rawURL)
-	resp, err := titleClient.Get(oembedURL)
+	oembedURL, _ := url.Parse("https://www.youtube.com/oembed")
+	q := oembedURL.Query()
+	q.Set("format", "json")
+	q.Set("url", rawURL)
+	oembedURL.RawQuery = q.Encode()
+
+	resp, err := titleClient.Get(oembedURL.String())
 	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return ""
 	}
@@ -160,8 +167,10 @@ func githubRepoMeta(rawURL string) (Meta, bool) {
 	}
 	owner, repo := parts[0], parts[1]
 
-	apiURL := "https://api.github.com/repos/" + owner + "/" + repo
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	apiURL, _ := url.Parse("https://api.github.com")
+	apiURL = apiURL.JoinPath("repos", owner, repo)
+
+	req, err := http.NewRequest(http.MethodGet, apiURL.String(), nil)
 	if err != nil {
 		return Meta{}, false
 	}

--- a/internal/urlfetch/urlfetch.go
+++ b/internal/urlfetch/urlfetch.go
@@ -75,7 +75,35 @@ func Fetch(rawURL string) Meta {
 	if title != "" && defaults != nil && defaults[0] == "github" {
 		title = strings.TrimSuffix(title, " · GitHub")
 	}
-	return Meta{Title: title, Tags: tags, FeedURL: extractFeedLink(body, rawURL)}
+
+	feedURL := extractFeedLink(body, rawURL)
+	if feedURL == "" {
+		feedURL = findFeedAtBase(rawURL)
+	}
+
+	return Meta{Title: title, Tags: tags, FeedURL: feedURL}
+}
+
+// findFeedAtBase fetches the scheme+host root of rawURL and looks for a feed
+// link there. Some sites only advertise feeds on their index page, not on
+// individual posts. Returns empty string if rawURL is already the root or no
+// feed link is found.
+func findFeedAtBase(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	if u.Path == "" || u.Path == "/" {
+		return ""
+	}
+
+	baseURL := u.Scheme + "://" + u.Host + "/"
+	body, _ := fetchPageHTML(baseURL)
+	if body == "" {
+		return ""
+	}
+
+	return extractFeedLink(body, baseURL)
 }
 
 // FetchTitle returns the title for rawURL. For YouTube URLs it uses the oEmbed

--- a/internal/urlfetch/urlfetch_test.go
+++ b/internal/urlfetch/urlfetch_test.go
@@ -1,6 +1,8 @@
 package urlfetch
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -256,6 +258,54 @@ func TestExtractTitle(t *testing.T) {
 				t.Errorf("extractTitle() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFetchFallsBackToBaseForFeed(t *testing.T) {
+	var postPath, rootPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		switch r.URL.Path {
+		case "/":
+			rootPath = r.URL.Path
+			_, _ = w.Write([]byte(`<html><head><title>Index</title><link rel="alternate" type="application/rss+xml" href="/feed.xml"></head></html>`))
+		case "/posts/hello":
+			postPath = r.URL.Path
+			_, _ = w.Write([]byte(`<html><head><title>Post</title></head></html>`))
+		}
+	}))
+	defer srv.Close()
+
+	meta := Fetch(srv.URL + "/posts/hello")
+	if postPath != "/posts/hello" {
+		t.Fatalf("post page not fetched: %q", postPath)
+	}
+	if rootPath != "/" {
+		t.Fatalf("root page not fetched for fallback: %q", rootPath)
+	}
+	want := srv.URL + "/feed.xml"
+	if meta.FeedURL != want {
+		t.Errorf("FeedURL = %q, want %q", meta.FeedURL, want)
+	}
+}
+
+func TestFindFeedAtBaseSkipsRoot(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><title>Root</title></head></html>`))
+	}))
+	defer srv.Close()
+
+	if got := findFeedAtBase(srv.URL + "/"); got != "" {
+		t.Errorf("expected empty for root URL, got %q", got)
+	}
+	if got := findFeedAtBase(srv.URL); got != "" {
+		t.Errorf("expected empty for host-only URL, got %q", got)
+	}
+	if hits != 0 {
+		t.Errorf("expected no fetches for root URLs, got %d", hits)
 	}
 }
 


### PR DESCRIPTION
The feed finder will now check the blog index or root url for rss/atom links if it doesn't find one on the article itself